### PR TITLE
Add example service with Zipkin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from nameko.rpc import rpc
 class Service:
     name = 'service'
     zipkin = Zipkin() # Dependency provider injects py_zipkin.zipkin.zipkin_span object
-    
+
     @rpc
     def method(self):
         assert self.zipkin.service_name == Service.name

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ ZIPKIN:
       url: http://localhost:9411/api/v1/spans
 ```
 
+Test it out locally
+-------------------
+
+We've provided an example docker-compose based stack that includes a nameko
+service and a Zipkin instance. To try it out, run `docker-compose up` in the
+root directory of the project. This will bring up three services: RabbitMQ
+(required by nameko), Zipkin, and an example Python service with both RPC
+and HTTP endpoints.
+
+Navigate to http://localhost:8000 to visit the example service, and if
+you then visit Zipkin dashboard (typically at http://localhost:9411),
+you should see some traces there!
+
 Planed changes
 --------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+  example_service:
+    build:
+      context: ./example_service/
+    ports:
+      - target: 8000
+        published: 8000
+        mode: host
+    volumes:
+      - type: bind
+        source: ./example_service/
+        target: /app/
+        volume:
+          nocopy: true
+    depends_on:
+      - rabbitmq
+
+  rabbitmq:
+    image: rabbitmq:3
+
+  zipkin:
+    image: openzipkin/zipkin
+    ports:
+      - target: 9411
+        published: 9411
+        mode: host

--- a/example_service/Dockerfile
+++ b/example_service/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6-slim
+
+RUN apt-get update && apt-get install -y build-essential
+RUN pip install nameko emplo-nameko-zipkin
+
+COPY . /app
+WORKDIR /app
+CMD nameko run --config=config.yml service

--- a/example_service/config.yml
+++ b/example_service/config.yml
@@ -1,0 +1,6 @@
+AMQP_URI: pyamqp://rabbitmq:5672
+ZIPKIN:
+  HANDLER: HttpHandler
+  HANDLER_PARAMS:
+    url: http://zipkin:9411/api/v1/spans
+  SAMPLE_RATE: 100.0

--- a/example_service/service.py
+++ b/example_service/service.py
@@ -1,4 +1,4 @@
-from nameko.rpc import rpc
+from nameko.rpc import rpc, RpcProxy
 from nameko.web.handlers import http
 
 from nameko_zipkin import Zipkin
@@ -7,6 +7,7 @@ from nameko_zipkin import Zipkin
 class ExampleService:
     name = 'example_service'
     zipkin = Zipkin()
+    example_service = RpcProxy('example_service')
 
     @rpc
     def traced_method(self):
@@ -14,4 +15,8 @@ class ExampleService:
 
     @http('GET', '/')
     def traced_handler(self, request):
-        return 'Find me in Zipkin!'
+        self.zipkin.update_binary_annotations({
+            'browser': request.headers.get('User-Agent'),
+            'url': request.url,
+        })
+        return self.example_service.traced_method()

--- a/example_service/service.py
+++ b/example_service/service.py
@@ -1,0 +1,17 @@
+from nameko.rpc import rpc
+from nameko.web.handlers import http
+
+from nameko_zipkin import Zipkin
+
+
+class ExampleService:
+    name = 'example_service'
+    zipkin = Zipkin()
+
+    @rpc
+    def traced_method(self):
+        return 'Find me in Zipkin!'
+
+    @http('GET', '/')
+    def traced_handler(self, request):
+        return 'Find me in Zipkin!'


### PR DESCRIPTION
Let's add an example docker-compose stack that demonstrates how a nameko service can be traced with Zipkin.